### PR TITLE
fix: rename update version configuration to correct grahpql mutation

### DIFF
--- a/api/kre/kre_version_test.go
+++ b/api/kre/kre_version_test.go
@@ -207,7 +207,7 @@ func TestVersionUpdateConfig(t *testing.T) {
 	srv, client := gqlMockServer(t, requestVars, `
 		{
 			"data": {
-				"updateVersionConfiguration": {
+				"updateVersionUserConfiguration": {
 					"config": {
 						"completed": true
 					}

--- a/api/kre/version/config.go
+++ b/api/kre/version/config.go
@@ -44,7 +44,7 @@ func (e ConfigVariableType) String() string {
 func (c *versionClient) UpdateConfig(runtime, versionName string, configVars []ConfigVariableInput) (bool, error) {
 	query := `
 		mutation UpdateConfig($input: UpdateConfigurationInput!) {
-			updateVersionConfiguration(input: $input) {
+			updateVersionUserConfiguration(input: $input) {
 				config {
 					completed
 				}
@@ -60,7 +60,7 @@ func (c *versionClient) UpdateConfig(runtime, versionName string, configVars []C
 	}
 
 	var respData struct {
-		UpdateVersionConfiguration struct {
+		UpdateVersionUserConfiguration struct {
 			Config struct {
 				Completed bool
 			}
@@ -69,7 +69,7 @@ func (c *versionClient) UpdateConfig(runtime, versionName string, configVars []C
 
 	err := c.client.MakeRequest(query, vars, &respData)
 
-	return respData.UpdateVersionConfiguration.Config.Completed, err
+	return respData.UpdateVersionUserConfiguration.Config.Completed, err
 }
 
 func (c *versionClient) GetConfig(runtime, versionName string) (*Config, error) {

--- a/cmd/kre/version/config/update.go
+++ b/cmd/kre/version/config/update.go
@@ -19,7 +19,7 @@ import (
 // NewUpdateConfigCmd manage config command for version.
 func NewUpdateConfigCmd(logger logging.Interface, cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set",
+		Use:   "set <version-name>",
 		Args:  args.ComposeArgsCheck(args.CheckServerFlag, cobra.ExactArgs(1)),
 		Short: "Set config variables values",
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
updateVersionConfiguration renaming to correct graphql mutation
updated help doc string for update version config cmd

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
updateVersionConfiguration graphql is not the correct mutation name

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
