### PR TITLE
fix: bind when product exists but has no version

### DIFF
--- a/internal/commands/product/bind.go
+++ b/internal/commands/product/bind.go
@@ -2,11 +2,16 @@ package product
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/konstellation-io/kli/internal/entity"
 	"github.com/konstellation-io/kli/internal/services/configuration"
 	productconfiguration "github.com/konstellation-io/kli/internal/services/product_configuration"
 	"github.com/konstellation-io/kli/pkg/krtutil"
+)
+
+var (
+	ErrProductExistsNoVersions = errors.New("error product exists but has no versions")
 )
 
 type BindProductOpts struct {
@@ -30,13 +35,6 @@ func (h *Handler) Bind(opts *BindProductOpts) error {
 		return err
 	}
 
-	var version *entity.Version
-
-	version, err = h.versionClient.Get(server, opts.ProductID, opts.VersionTag)
-	if err != nil {
-		return err
-	}
-
 	productConfig, err := h.configService.GetConfiguration(opts.ProductID, opts.LocalPath)
 	if err != nil && !errors.Is(err, productconfiguration.ErrProductConfigNotFound) {
 		return err
@@ -44,6 +42,11 @@ func (h *Handler) Bind(opts *BindProductOpts) error {
 
 	if productConfig != nil && !opts.Force {
 		return ErrProductConfigurationAlreadyExists
+	}
+
+	version, err := h.getVersion(server, opts)
+	if err != nil {
+		return err
 	}
 
 	err = h.configService.WriteConfiguration(&productconfiguration.KaiProductConfiguration{
@@ -57,4 +60,18 @@ func (h *Handler) Bind(opts *BindProductOpts) error {
 	h.renderer.RenderProductBinded(opts.ProductID)
 
 	return nil
+}
+
+func (h *Handler) getVersion(server *configuration.Server, opts *BindProductOpts) (*entity.Version, error) {
+	version, err := h.versionClient.Get(server, opts.ProductID, opts.VersionTag)
+	if err != nil {
+		if strings.Contains(err.Error(), ErrProductExistsNoVersions.Error()) {
+			h.logger.Warn("Product exists but has no versions, using an empty version")
+			version = &entity.Version{}
+		} else {
+			return nil, err
+		}
+	}
+
+	return version, nil
 }

--- a/internal/commands/product/bind.go
+++ b/internal/commands/product/bind.go
@@ -67,6 +67,7 @@ func (h *Handler) getVersion(server *configuration.Server, opts *BindProductOpts
 	if err != nil {
 		if strings.Contains(err.Error(), ErrProductExistsNoVersions.Error()) {
 			h.logger.Warn("Product exists but has no versions, using an empty version")
+
 			version = &entity.Version{}
 		} else {
 			return nil, err

--- a/internal/commands/product/test-product.yaml
+++ b/internal/commands/product/test-product.yaml
@@ -1,0 +1,4 @@
+version: ""
+description: ""
+config: {}
+workflows: []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
catch of custom errors when retrieving a version

this is to inform kai of the following scenario: a product exists but no versions have been created, so the kli needs to create an empty version when binding

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
